### PR TITLE
Support Laravel 12 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/bus": "^11.0",
-        "illuminate/contracts": "^11.0",
-        "illuminate/console": "^11.0",
-        "illuminate/database": "^11.0",
-        "illuminate/filesystem": "^11.0",
-        "illuminate/http": "^11.0",
-        "illuminate/queue": "^11.0",
-        "illuminate/support": "^11.0",
+        "illuminate/bus": "^11.0 || ^12.0",
+        "illuminate/contracts": "^11.0 || ^12.0",
+        "illuminate/console": "^11.0 || ^12.0",
+        "illuminate/database": "^11.0 || ^12.0",
+        "illuminate/filesystem": "^11.0 || ^12.0",
+        "illuminate/http": "^11.0 || ^12.0",
+        "illuminate/queue": "^11.0 || ^12.0",
+        "illuminate/support": "^11.0 || ^12.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {


### PR DESCRIPTION
Updated composer.json to support both Laravel 11 and 12 by changing the version constraints for the following illuminate/* dependencies: