### PR TITLE
feat: add Laravel 12 and 13 support 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/bus": "^11.0",
-        "illuminate/contracts": "^11.0",
-        "illuminate/console": "^11.0",
-        "illuminate/database": "^11.0",
-        "illuminate/filesystem": "^11.0",
-        "illuminate/http": "^11.0",
-        "illuminate/queue": "^11.0",
-        "illuminate/support": "^11.0",
+        "illuminate/bus": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/console": "^11.0|^12.0|^13.0",
+        "illuminate/database": "^11.0|^12.0|^13.0",
+        "illuminate/filesystem": "^11.0|^12.0|^13.0",
+        "illuminate/http": "^11.0|^12.0|^13.0",
+        "illuminate/queue": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {

--- a/src/Database/TursoConnection.php
+++ b/src/Database/TursoConnection.php
@@ -6,6 +6,7 @@ namespace RichanFongdasen\Turso\Database;
 
 use Exception;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Grammar;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Str;
@@ -54,20 +55,25 @@ class TursoConnection extends Connection
 
     protected function getDefaultQueryGrammar(): TursoQueryGrammar
     {
-        $grammar = new TursoQueryGrammar();
-        $grammar->setConnection($this);
-
-        $this->withTablePrefix($grammar);
-
-        return $grammar;
+        return $this->newGrammar(TursoQueryGrammar::class);
     }
 
     protected function getDefaultSchemaGrammar(): TursoSchemaGrammar
     {
-        $grammar = new TursoSchemaGrammar();
-        $grammar->setConnection($this);
+        return $this->newGrammar(TursoSchemaGrammar::class);
+    }
 
-        $this->withTablePrefix($grammar);
+    private function newGrammar(string $class): mixed
+    {
+        // Laravel 12+ removed setConnection() from Grammar and requires
+        // a Connection argument in the constructor instead.
+        if (! method_exists(Grammar::class, 'setConnection')) {
+            return new $class($this);
+        }
+
+        $grammar = new $class();
+        $grammar->setConnection($this);
+        $grammar->setTablePrefix($this->getTablePrefix());
 
         return $grammar;
     }

--- a/src/Database/TursoSchemaBuilder.php
+++ b/src/Database/TursoSchemaBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RichanFongdasen\Turso\Database;
 
+use Illuminate\Database\Grammar;
 use Illuminate\Database\Schema\SQLiteBuilder;
 use RichanFongdasen\Turso\Exceptions\FeatureNotSupportedException;
 
@@ -69,7 +70,11 @@ class TursoSchemaBuilder extends SQLiteBuilder
     protected function grammar(): TursoSchemaGrammar
     {
         if (! ($this->grammar instanceof TursoSchemaGrammar)) {
-            $this->grammar = new TursoSchemaGrammar();
+            if (! method_exists(Grammar::class, 'setConnection')) {
+                $this->grammar = new TursoSchemaGrammar($this->connection);
+            } else {
+                $this->grammar = new TursoSchemaGrammar();
+            }
         }
 
         return $this->grammar;

--- a/src/Database/TursoSchemaGrammar.php
+++ b/src/Database/TursoSchemaGrammar.php
@@ -9,24 +9,32 @@ use Override;
 
 class TursoSchemaGrammar extends SQLiteGrammar
 {
-    public function compileDropAllIndexes(): string
+    public function compileDropAllIndexes($schema = null): string
     {
-        return "SELECT 'DROP INDEX IF EXISTS \"' || name || '\";' FROM sqlite_schema WHERE type = 'index' AND name NOT LIKE 'sqlite_%'";
+        $schema = $this->wrapValue($schema ?? 'main');
+
+        return "SELECT 'DROP INDEX IF EXISTS \"' || name || '\";' FROM {$schema}.sqlite_schema WHERE type = 'index' AND name NOT LIKE 'sqlite_%'";
     }
 
-    public function compileDropAllTables(): string
+    public function compileDropAllTables($schema = null): string
     {
-        return "SELECT 'DROP TABLE IF EXISTS \"' || name || '\";' FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%'";
+        $schema = $this->wrapValue($schema ?? 'main');
+
+        return "SELECT 'DROP TABLE IF EXISTS \"' || name || '\";' FROM {$schema}.sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%'";
     }
 
-    public function compileDropAllTriggers(): string
+    public function compileDropAllTriggers($schema = null): string
     {
-        return "SELECT 'DROP TRIGGER IF EXISTS \"' || name || '\";' FROM sqlite_schema WHERE type = 'trigger' AND name NOT LIKE 'sqlite_%'";
+        $schema = $this->wrapValue($schema ?? 'main');
+
+        return "SELECT 'DROP TRIGGER IF EXISTS \"' || name || '\";' FROM {$schema}.sqlite_schema WHERE type = 'trigger' AND name NOT LIKE 'sqlite_%'";
     }
 
-    public function compileDropAllViews(): string
+    public function compileDropAllViews($schema = null): string
     {
-        return "SELECT 'DROP VIEW IF EXISTS \"' || name || '\";' FROM sqlite_schema WHERE type = 'view'";
+        $schema = $this->wrapValue($schema ?? 'main');
+
+        return "SELECT 'DROP VIEW IF EXISTS \"' || name || '\";' FROM {$schema}.sqlite_schema WHERE type = 'view'";
     }
 
     #[Override]


### PR DESCRIPTION
Hi, thanks for the package. I've been using it on a small side project for a while, and was keen to upgrade it to Laravel 13. These are the changes I found I needed:

- Widen illuminate/* constraints from ^11.0 to ^11.0|^12.0|^13.0
- Pass Connection to Grammar constructors (required in L12+), with L11 backwards compatibility
- Add $schema parameter to compileDropAllTables/Views (L12+ signature)

**Testing**

Under Laravel 11, Laravel 12 and Laravel 13 - I manually verified the following runs without issue against a test Turso database: 
- `php artisan migrate:refresh`
- Model::get()
- Model::create()
